### PR TITLE
Update server.php

### DIFF
--- a/nucleus/xmlrpc/server.php
+++ b/nucleus/xmlrpc/server.php
@@ -156,7 +156,8 @@ function _addDatedItem($blogid, $username, $password, $title, $body, $more, $pub
 /**
   * Updates an item. Username and password are required to login
   */
-function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed)
+//function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed)
+function _edititem($itemid, $username, $password, $catid, $title, $body, $more, $wasdraft, $publish, $closed, $timestamp=0)
 {
     global $manager;
 
@@ -181,7 +182,7 @@ function _edititem($itemid, $username, $password, $catid, $title, $body, $more, 
     }
 
     // 3. update item
-    ITEM::update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, 0);
+    ITEM::update($itemid, $catid, $title, $body, $more, $closed, $wasdraft, $publish, $timestamp);
 
     return new xmlrpcresp(new xmlrpcval(1, "boolean"));
 }


### PR DESCRIPTION
現状ではクライアント使用時にエラーを起こすので、api_metaweblog.inc.php と同様に以前コミットした以下の修正を復活。
_edititem() : 関数の引数に$timestampを追加。ITEM::update() に 0 の替わりに$timestampを渡すよう修正。